### PR TITLE
fix(design, geo submission): Corrects input pairing in design and also increases flexibility for GEO submission files

### DIFF
--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -311,7 +311,7 @@ homer:
 deeptools:
     threads: 8
     alignmentsieve: --minMappingQuality 30 
-    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4
+    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10
 
 macs:
     version: 2

--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -311,7 +311,7 @@ homer:
 deeptools:
     threads: 8
     alignmentsieve: --minMappingQuality 30 
-    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM
+    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4
 
 macs:
     version: 2

--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -311,7 +311,7 @@ homer:
 deeptools:
     threads: 8
     alignmentsieve: --minMappingQuality 30 
-    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4 --samFlagInclude 3
+    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4
 
 macs:
     version: 2

--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -311,7 +311,7 @@ homer:
 deeptools:
     threads: 8
     alignmentsieve: --minMappingQuality 30 
-    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4
+    bamcoverage: --extendReads -bs 1 --normalizeUsing RPKM --minMappingQuality 10 --samFlagExclude 4 --samFlagInclude 3
 
 macs:
     version: 2

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1025,7 +1025,13 @@ class GEOFiles(BaseModel):
 
         for row in self.design.itertuples():
             sample_name = row.sample_name if self.assay not in ["ChIP", "CUT&TAG"] else f"{row.sample_name}_{row.ip}"
-            is_paired = hasattr(row, "r2") or hasattr(row, "ip_r2")
+
+            is_paired = False
+            if hasattr(row, "r2") and row.r2:
+                is_paired = True
+            elif hasattr(row, "ip_r2") and row.ip_r2:
+                is_paired = True
+
             fqs = generate_fastq_raw_names(sample_name, is_paired)
             fastq.update(fqs)
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -929,6 +929,7 @@ class GEOFiles(BaseModel):
     sample_names: List[str]
     config: dict
     design: pd.DataFrame
+    extensions_allowed: List[str] = [".txt", ".bigWig", ".bed", ".tsv", ".vcf.gz"]
 
     processed_files: Optional[List[Union[str, pathlib.Path]]] = None
 
@@ -947,7 +948,8 @@ class GEOFiles(BaseModel):
 
     @property
     def processed_data_files(self) -> pd.DataFrame:
-        wanted_exts = [".txt", ".bigWig", ".bed", '.tsv']
+        
+        wanted_exts = self.extensions_allowed
         unwanted_files = [*self.md5sums]
 
         # Create a DataFrame with the processed files

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1397,7 +1397,7 @@ class Output(BaseModel):
     @property
     def geo_files(self):
         if self.geo_submission_files:
-            return GEOFiles(assay=self.assay).files
+            return GEOFiles(assay=self.assay, design=self.design_dataframe, config=self.config).files
         else:
             return []
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -999,11 +999,6 @@ class GEOFiles(BaseModel):
             ),
         )
 
-        # Convert the output file name to a pathlib.Path object
-        df = df.assign(
-            output_file_name=lambda df: df["output_file_name"].apply(pathlib.Path),
-        )
-
         return df
 
     @property

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -248,10 +248,11 @@ class FastqSetIP(FastqSet):
     name: str = Field(default=None, description="Name of the sample set")
     r1: FastqFileIP
     r2: Optional[FastqFileIP] = None
+    ip: str = Field(default=None, description="IP performed on the sample")
 
     @property
     def ip_or_control_name(self) -> str:
-        return self.r1.ip
+        return self.ip if self.ip else self.r1.ip
 
     @property
     def sample_name(self) -> str:
@@ -741,12 +742,14 @@ class DesignIP(BaseModel):
         for _, row in df.iterrows():
             ip = FastqSetIP(
                 name=row["sample_name"],
+                ip=row["ip"],
                 r1=FastqFileIP(path=row["ip_r1"]),
                 r2=FastqFileIP(path=row["ip_r2"]) if row["ip_r2"] else None,
             )
             control = (
                 FastqSetIP(
                     name=row["sample_name"],
+                    ip=row["control"],
                     r1=FastqFileIP(path=row["control_r1"])
                     if row["control_r1"]
                     else None,
@@ -764,7 +767,6 @@ class DesignIP(BaseModel):
             metadata.append(
                 Metadata(**{k: v for k, v in row.items() if k not in non_metadata_keys})
             )
-
         return cls(experiments=experiments, metadata=metadata, **kwargs)
 
     @classmethod
@@ -921,7 +923,7 @@ def generate_fastq_raw_names(sample_name: str, is_paired: bool = True) -> Dict[s
     """
 
     if is_paired:
-        exts = ["_R1.fastq.gz", "_R2.fastq.gz"]
+        exts = ["_1.fastq.gz", "_2.fastq.gz"]
     else:
         exts = [".fastq.gz"]
     fq = [f"{sample_name}{ext}" for ext in exts]

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1291,6 +1291,13 @@ class Output(BaseModel):
             return pf.files
         else:
             return []
+    
+    @property
+    def geo_files(self):
+        if self.geo_submission_files:
+            return self.geo_files
+        else:
+            return []
 
 
 class RNAOutput(Output):
@@ -1328,7 +1335,7 @@ class RNAOutput(Output):
             ).files
         )
 
-        files.extend(GEOFiles(assay=self.assay).files)
+        files.extend(self.geo_files)
 
         for file_list in (
             self.bigwigs,
@@ -1402,7 +1409,7 @@ class NonRNAOutput(Output):
         )
 
 
-        files.extend(GEOFiles(assay=self.assay).files)
+        files.extend(self.geo_files)
 
         for file_list in (
             self.bigwigs,
@@ -1481,7 +1488,7 @@ class ChIPOutput(NonRNAOutput):
         )
 
         if self.geo_submission_files:
-            files.extend(GEOFiles(assay=self.assay).files)
+            files.extend(self.geo_files)
 
         for file_list in (
             self.bigwigs,

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -631,7 +631,6 @@ class DesignIP(BaseModel):
             .assign(
                 has_control=lambda x: x["path_control"].notnull(),
             )
-            .drop_duplicates('path_ip')
         )
 
         # Group the files by the sample base
@@ -1193,6 +1192,7 @@ class PlotFiles(BaseModel):
 
 class Output(BaseModel):
     assay: Literal["ChIP", "ATAC", "RNA", "SNP"]
+    config: dict
     run_design: Union[Design, DesignIP]
     sample_names: List[str]
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -997,11 +997,15 @@ class GEOFiles(BaseModel):
                 [
                     df["ext"] == ".bigWig",
                     df["ext"] == ".bed",
-                    df["ext"] == ".txt",
+                    df['ext'] == ".tsv",
+                    df['ext'] == ".vcf.gz",
                 ],
-                ["signal", "peaks", "counts"],
+                ["signal", "peaks", "counts", 'variants'],
+                default="other",
             ),
         )
+
+        df = df[df.file_type != "other"]
 
         return df
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1295,7 +1295,7 @@ class Output(BaseModel):
     @property
     def geo_files(self):
         if self.geo_submission_files:
-            return self.geo_files
+            return GEOFiles(assay=self.assay).files
         else:
             return []
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -947,7 +947,7 @@ class GEOFiles(BaseModel):
 
     @property
     def processed_data_files(self) -> pd.DataFrame:
-        wanted_exts = [".txt", ".bigWig", ".bed"]
+        wanted_exts = [".txt", ".bigWig", ".bed", '.tsv']
         unwanted_files = [*self.md5sums]
 
         # Create a DataFrame with the processed files

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -638,7 +638,7 @@ class DesignIP(BaseModel):
         experiments = []
         for base, group in df.groupby("sample_base"):
             name_without_ip = group["sample_base_without_ip"].iloc[0]
-
+            
             match group.shape[0]:
                 case 1:
                     # Single end experiment no control
@@ -659,10 +659,19 @@ class DesignIP(BaseModel):
 
                 case 4:
                     # Paired end experiment with control
+
+                    # | path_ip | path_control |
+                    # |---------|--------------|
+                    # | r1      | r1           |
+                    # | r1      | r2           |
+                    # | r2      | r1           |
+                    # | r2      | r2           |
+
+
                     ip = FastqSetIP(
                         name=name_without_ip,
                         r1=FastqFileIP(path=group["path_ip"].iloc[0]),
-                        r2=FastqFileIP(path=group["path_ip"].iloc[1]),
+                        r2=FastqFileIP(path=group["path_ip"].iloc[2]),
                     )
                     control = FastqSetIP(
                         name=name_without_ip,

--- a/seqnado/workflow/rules/geo_submission.smk
+++ b/seqnado/workflow/rules/geo_submission.smk
@@ -37,8 +37,12 @@ def get_symlinked_files(wc: Any = None) -> List[str]:
                          processed_files=[str(p) for p in OUTPUT.files],
                          )
 
-    processed_files = geo_files.processed_data_files['output_file_name'].tolist()
-    processed_files = [outdir / fn for fn in processed_files]
+
+
+    if processed_files := geo_files.processed_data_files['output_file_name'].tolist():
+        processed_files = [outdir / fn for fn in processed_files]
+    else:
+        processed_files = []
 
 
     return [*fastqs, *processed_files]

--- a/seqnado/workflow/rules/geo_submission.smk
+++ b/seqnado/workflow/rules/geo_submission.smk
@@ -39,9 +39,8 @@ def get_symlinked_files(wc: Any = None) -> List[str]:
 
 
 
-    processed_files = geo_files.processed_data_files['output_file_name']
-
-    if processed_files.any():
+    if not geo_files.processed_data_files.empty:
+        processed_files = geo_files.processed_data_files['output_file_name'].tolist()
         processed_files = [outdir / fn for fn in processed_files]
     else:
         processed_files = []

--- a/seqnado/workflow/rules/geo_submission.smk
+++ b/seqnado/workflow/rules/geo_submission.smk
@@ -40,8 +40,7 @@ def get_symlinked_files(wc: Any = None) -> List[str]:
 
 
     if not geo_files.processed_data_files.empty:
-        processed_files = geo_files.processed_data_files['output_file_name'].astype(str).tolist()
-        processed_files = [outdir / fn for fn in processed_files]
+        processed_files = [outdir / str(fn) for (index, fn) in geo_files.processed_data_files['output_file_name'].items()]
     else:
         processed_files = []
 

--- a/seqnado/workflow/rules/geo_submission.smk
+++ b/seqnado/workflow/rules/geo_submission.smk
@@ -39,7 +39,9 @@ def get_symlinked_files(wc: Any = None) -> List[str]:
 
 
 
-    if processed_files := geo_files.processed_data_files['output_file_name'].tolist():
+    processed_files = geo_files.processed_data_files['output_file_name']
+
+    if processed_files.any():
         processed_files = [outdir / fn for fn in processed_files]
     else:
         processed_files = []

--- a/seqnado/workflow/rules/geo_submission.smk
+++ b/seqnado/workflow/rules/geo_submission.smk
@@ -40,7 +40,7 @@ def get_symlinked_files(wc: Any = None) -> List[str]:
 
 
     if not geo_files.processed_data_files.empty:
-        processed_files = geo_files.processed_data_files['output_file_name'].tolist()
+        processed_files = geo_files.processed_data_files['output_file_name'].astype(str).tolist()
         processed_files = [outdir / fn for fn in processed_files]
     else:
         processed_files = []

--- a/seqnado/workflow/rules/pileup_default.smk
+++ b/seqnado/workflow/rules/pileup_default.smk
@@ -7,6 +7,7 @@ def format_deeptools_options(wildcards, options):
     if not is_paired:
         options = re.sub(r"--extendReads", "", options)
         options = re.sub(r"-e", "", options)
+        options = re.sub(r"--samFlagInclude 3", "", options)
     if not options:
         return ""
     else:

--- a/seqnado/workflow/rules/pileup_norm.smk
+++ b/seqnado/workflow/rules/pileup_norm.smk
@@ -124,9 +124,11 @@ rule count_bam:
         counts="seqnado_output/counts/counts.tsv",
     params:
         options='-p --countReadPairs',
+    log:
+        "seqnado_output/logs/counts/{group}.log",
     threads: 8
     shell:
-        "featureCounts -a {input.tiles} -a {input.tiles} -t tile -o {output.counts} {input.bam} -T {threads} {params.options}"
+        "featureCounts -a {input.tiles} -a {input.tiles} -t tile -o {output.counts} {input.bam} -T {threads} {params.options} > {log} 2>&1"
 
 
 rule setup_for_scaling_factors:

--- a/seqnado/workflow/rules/pileup_norm.smk
+++ b/seqnado/workflow/rules/pileup_norm.smk
@@ -125,7 +125,7 @@ rule count_bam:
     params:
         options='-p --countReadPairs',
     log:
-        "seqnado_output/logs/counts/{group}.log",
+        "seqnado_output/logs/counts/readcounts.log",
     threads: 8
     shell:
         "featureCounts -a {input.tiles} -a {input.tiles} -t tile -o {output.counts} {input.bam} -T {threads} {params.options} > {log} 2>&1"

--- a/seqnado/workflow/scripts/produce_data_processing_protocol.py
+++ b/seqnado/workflow/scripts/produce_data_processing_protocol.py
@@ -31,7 +31,7 @@ def bowtie2_version():
 
 def featureCounts_version():
     cmd = 'featureCounts -v'
-    version = subprocess.check_output(cmd, shell=True).decode().strip()
+    version = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode().strip().replace('featureCounts v', '')
     return version
 
 def bamCoverage_version():
@@ -76,7 +76,7 @@ BigWig files were generated using deepTools {bamCoverage_version()} with the fol
 """
 
 if assay == 'RNA':
-    content += f"""Strands were separated using the --filterRNAstrand option"""
+    content += f"""Strands were separated using the --filterRNAstrand option. """
     content += f"""Alignments were quantified using featureCounts v{featureCounts_version()} with the following parameters: {config['featurecounts']['options']}"""
 
 
@@ -89,7 +89,8 @@ if assay in ['ChIP', 'ATAC', 'CUT&TAG']:
 
 
 
-content = content.strip().replace('the following parameters: False', 'with default parameters')
+content = content.strip().replace('the following parameters: False', 'with default parameters').replace('/n/n', '/n')
+content = "\n".join([l.strip('\n') for l in content.splitlines() if l.strip()])
 
 
 with open(snakemake.output[0], 'w') as f:

--- a/seqnado/workflow/scripts/produce_data_processing_protocol.py
+++ b/seqnado/workflow/scripts/produce_data_processing_protocol.py
@@ -42,7 +42,7 @@ def bamCoverage_version():
 def picard_version():
     cmd = 'picard MarkDuplicates --version'
     try:
-        version = subprocess.check_output(cmd, shell=True).decode().strip()
+        version = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode().strip().removeprefix('Version:')
     except subprocess.CalledProcessError:
         version = "3.1.1"
     return version

--- a/seqnado/workflow/snakefile_atac
+++ b/seqnado/workflow/snakefile_atac
@@ -46,6 +46,7 @@ symlink_fastq_files(DESIGN, output_dir="seqnado_output/fastqs")
 SAMPLE_NAMES = DESIGN.sample_names
 OUTPUT = ATACOutput(
     assay=ASSAY,
+    config=config,
     run_design=DESIGN,
     sample_names=SAMPLE_NAMES,
     **config

--- a/seqnado/workflow/snakefile_chip
+++ b/seqnado/workflow/snakefile_chip
@@ -50,6 +50,7 @@ CONTROL = DESIGN.controls_performed
 # Define output files
 OUTPUT = ChIPOutput(
     assay=ASSAY,
+    config=config,
     run_design=DESIGN,
     sample_names=SAMPLE_NAMES,
     ip_names=IP,

--- a/seqnado/workflow/snakefile_rna
+++ b/seqnado/workflow/snakefile_rna
@@ -57,6 +57,7 @@ config["project_name"] = PROJECT_NAME
 # Define output files
 OUTPUT = RNAOutput(
     assay=ASSAY,
+    config=config,
     run_design=DESIGN,
     sample_names=SAMPLE_NAMES,
     run_deseq2=RUN_DESEQ2,

--- a/seqnado/workflow/snakefile_snp
+++ b/seqnado/workflow/snakefile_snp
@@ -45,6 +45,7 @@ symlink_fastq_files(DESIGN, output_dir="seqnado_output/fastqs")
 SAMPLE_NAMES = DESIGN.sample_names
 OUTPUT = SNPOutput(
     assay=ASSAY,
+    config=config,
     run_design=DESIGN,
     sample_names=SAMPLE_NAMES,
     **config


### PR DESCRIPTION
- Inputs did not correctly have both paired end files specified (R1 was repeated twice) due to a bug in the pairing code. Now fixed
- GEO submission now allows for multiple peak callers/pileup generators to be used
- Fixes error when changing IP and control names in the design. Will now correctly allow this to occur.