### PR TITLE
Fix genome plots

### DIFF
--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1432,6 +1432,7 @@ class SpikeInFiles(BaseModel):
 
 
 class PlotFiles(BaseModel):
+    perform_plotting: bool = False
     plotting_coordinates: Optional[Union[str, pathlib.Path]] = None
     plotting_format: Literal["svg", "png", "pdf"] = "svg"
 
@@ -1483,7 +1484,7 @@ class Output(BaseModel):
 
     geo_submission_files: bool = False
 
-    make_plots: bool = False
+    perform_plotting: bool = False
     plotting_coordinates: Optional[Union[str, pathlib.Path]] = None
 
     # Correct plotting_coordinates type as it may be False
@@ -1554,7 +1555,7 @@ class Output(BaseModel):
 
     @property
     def plots(self):
-        if self.make_plots:
+        if self.perform_plotting:
             pf = PlotFiles(
                 plotting_coordinates=self.plotting_coordinates, plotting_format="svg"
             )

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1485,6 +1485,7 @@ class Output(BaseModel):
     geo_submission_files: bool = False
 
     perform_plotting: bool = False
+    plotting_format: Literal["svg", "png", "pdf"] = "svg"
     plotting_coordinates: Optional[Union[str, pathlib.Path]] = None
 
     # Correct plotting_coordinates type as it may be False
@@ -1557,7 +1558,7 @@ class Output(BaseModel):
     def plots(self):
         if self.perform_plotting:
             pf = PlotFiles(
-                plotting_coordinates=self.plotting_coordinates, plotting_format="svg"
+                plotting_coordinates=self.plotting_coordinates, plotting_format=self.plotting_format
             )
             return pf.files
         else:

--- a/seqnado/workflow/rules/visualisation.smk
+++ b/seqnado/workflow/rules/visualisation.smk
@@ -15,6 +15,9 @@ rule generate_plotnado_visualisation:
         outdir="seqnado_output/genome_browser_plots/",
         regions=config['plotting_coordinates'],
         plotting_format=config['plotting_format'],
+    resources:
+        mem="1.5GB",
+         runtime=lambda wildcards, attempt: define_time_requested(initial_value=1, attempts=attempt, scale=SCALE_RESOURCES),
     container:
         "library://asmith151/plotnado/plotnado:latest"
     script:

--- a/seqnado/workflow/rules/visualisation.smk
+++ b/seqnado/workflow/rules/visualisation.smk
@@ -14,6 +14,7 @@ rule generate_plotnado_visualisation:
         genes=config['plotting_genes'],
         outdir="seqnado_output/genome_browser_plots/",
         regions=config['plotting_coordinates'],
+        plotting_format=config['plotting_format'],
     container:
         "library://asmith151/plotnado/plotnado:latest"
     script:

--- a/seqnado/workflow/scripts/run_plotnado.py
+++ b/seqnado/workflow/scripts/run_plotnado.py
@@ -1,20 +1,16 @@
-# %%
 import pathlib
-import re
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import plotnado.api as pn
 import pyranges as pr
 import seaborn as sns
-import numpy as np
 
 plt.rcParams["font.family"] = "sans-serif"
 plt.rcParams["svg.fonttype"] = "none"
 
-# %%
 ASSAY = snakemake.params.assay
-
 
 
 # Load the tracks into a DataFrame
@@ -40,17 +36,15 @@ if ASSAY == "ChIP":
     df["antibody"] = df["name"].str.split("_").str[-1]
 
 
-
 # Load the regions
 coords = pr.read_bed(snakemake.params.regions)
-
+plotting_format = snakemake.params.plotting_format
 # Generate the figure
-# %%
 fig = pn.Figure(
     autospacing=True,
 )
 
-fig.add_track('scale')
+fig.add_track("scale")
 
 if snakemake.params.genes:
     fig.add_track(
@@ -97,18 +91,15 @@ for track in df.itertuples():
     )
     fig.add_track(t)
 
-# %%
 
 outdir = pathlib.Path(snakemake.params.outdir)
 for region in coords.df.itertuples():
-
-    fig_name = f"{region.Chromosome}-{region.Start}-{region.End}" if not hasattr(region, "Name") and not region.Name else region.Name
+    fig_name = (
+        f"{region.Chromosome}-{region.Start}-{region.End}"
+        if not hasattr(region, "Name") and not region.Name
+        else region.Name
+    )
     region_coords = f"{region.Chromosome}:{region.Start}-{region.End}"
-    fig.save(output=outdir / f"{fig_name}.svg", gr=region_coords)
-    
-# %%
+    fig.save(output=outdir / f"{fig_name}.{plotting_format}", gr=region_coords)
+
 fig.to_toml(snakemake.output.template)
-
-
-
-

--- a/seqnado/workflow/scripts/run_plotnado.py
+++ b/seqnado/workflow/scripts/run_plotnado.py
@@ -17,6 +17,7 @@ ASSAY = snakemake.params.assay
 df = pd.DataFrame([pathlib.Path(p) for p in snakemake.input.data], columns=["path"])
 df["name"] = df["path"].apply(lambda x: x.stem)
 df["type"] = df["path"].apply(lambda x: x.suffix)
+df["type"] = pd.Categorical(df["type"], categories=[".bigWig", ".bed"], ordered=True)
 df["normalisation"] = np.where(
     df["type"] != ".bed", df["path"].apply(lambda x: x.parts[-2]), ""
 )
@@ -28,7 +29,7 @@ df["method"] = np.where(
 df = df.sort_values(by=["name", "type", "method", "normalisation"])
 
 df["track_name"] = (
-    df["name"] + "-" + df["method"] + "-" + df["normalisation"] + df["type"]
+    df["name"] + "-" + df["method"] + "-" + df["normalisation"] + df["type"].astype(str)
 )
 df["track_name"] = df["track_name"].str.replace("-.", ".")
 


### PR DESCRIPTION
This pull request includes several changes to the `seqnado` project, focusing on adding flexibility to plotting options and improving the code's readability and functionality. The most important changes include the introduction of a new `perform_plotting` flag, the addition of a `plotting_format` parameter, and various updates to the plotting script.

### Enhancements to plotting options:

* [`seqnado/design.py`](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1435): Introduced `perform_plotting` flag and `plotting_format` parameter in both `PlotFiles` and `Output` classes, and updated the `plots` property to use these new attributes. [[1]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1435) [[2]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690L1486-R1488) [[3]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690L1557-R1561)

### Updates to workflow rules and scripts:

* [`seqnado/workflow/rules/visualisation.smk`](diffhunk://#diff-c8f75bf2884e28e25ee9bb2d3b57556e76e3bb86e5fac1579e5f95ef624e7e3fR17-R20): Added `plotting_format` parameter to the `generate_plotnado_visualisation` rule and defined memory and runtime resources.
* [`seqnado/workflow/scripts/run_plotnado.py`](diffhunk://#diff-1ea4ddc3304070aa9f3507b8563c08eadd2cb0ef9dc6e9c9ed5c95d0d8a98232L1-R20): Improved imports, added `plotting_format` parameter handling, and updated figure saving logic to use the specified plotting format. [[1]](diffhunk://#diff-1ea4ddc3304070aa9f3507b8563c08eadd2cb0ef9dc6e9c9ed5c95d0d8a98232L1-R20) [[2]](diffhunk://#diff-1ea4ddc3304070aa9f3507b8563c08eadd2cb0ef9dc6e9c9ed5c95d0d8a98232L35-R48) [[3]](diffhunk://#diff-1ea4ddc3304070aa9f3507b8563c08eadd2cb0ef9dc6e9c9ed5c95d0d8a98232L100-L114)