### PR TITLE
Fix: add preset genome fasta

### DIFF
--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -20,6 +20,7 @@ class GenomeConfig(BaseModel):
     gtf: str
     blacklist: Optional[str] = None
     genes: Optional[str] = None
+    fasta: Optional[str] = None
 
 class WorkflowConfig(BaseModel):
     # Core Configuration
@@ -71,6 +72,10 @@ class WorkflowConfig(BaseModel):
     fasta_index: Optional[str] = None
     snp_database: Optional[str] = None
     
+    # Methylation-Specific
+    call_methylation: bool = False
+    methylation_assay: Literal["taps", "bisulfite", "False"] = "False"
+
     # UCSC Hub
     make_ucsc_hub: bool = False
     UCSC_hub_directory: str = "seqnado_output/hub/"
@@ -280,7 +285,7 @@ def get_conditional_features(assay: str, genome_config: dict) -> dict:
         features["call_snps"] = get_user_input("Call SNPs?", default="no", is_boolean=True)
         if features["call_snps"]:
             features["snp_calling_method"] = get_user_input("SNP caller:", choices=["bcftools", "deepvariant"], default="bcftools")
-            features["fasta"] = get_user_input("Path to reference fasta:", default="path/to/reference.fasta", is_path=True)
+            features["fasta"] = genome_config.fasta if genome_config.fasta else get_user_input("Path to reference fasta:", default='no')
             features["fasta_index"] = get_user_input("Path to reference fasta index:", default="path/to/reference.fasta.fai", is_path=True)
             features["snp_database"] = get_user_input("Path to SNP database:", default="path/to/snp_database", is_path=True)
     
@@ -288,7 +293,7 @@ def get_conditional_features(assay: str, genome_config: dict) -> dict:
     if assay == "meth":
         features["call_methylation"] = get_user_input("Call methylation?", default="no", is_boolean=True)
         if features["call_methylation"]:
-            features["fasta"] = get_user_input("Path to reference fasta:", default="path/to/reference.fasta", is_path=True)
+            features["fasta"] = genome_config.fasta if genome_config.fasta else get_user_input("Path to reference fasta:", default='no')
             features["methylation_assay"] = get_user_input("Methylation assay:", choices=["taps", "bisulfite"], default="taps")
 
     # Consensus Counts

--- a/seqnado/workflow/config/genomes_template.json
+++ b/seqnado/workflow/config/genomes_template.json
@@ -4,6 +4,8 @@
         "star_index": "PATH_TO_STAR/dm6/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "PATH/dm6/UCSC/sequence/dm6.chrom.sizes",
         "gtf": "PATH/dm6/UCSC/genes/dm6.ncbiRefSeq.gtf",
-        "blacklist": "PATH/dm6/dm6-blacklist.v2.bed.gz"
+        "blacklist": "PATH/dm6/dm6-blacklist.v2.bed.gz",
+        "genes": "PATH/dm6/dm6_genes.bed",
+        "fasta": "PATH/dm6/UCSC/sequence/dm6.fa"
     }
 }

--- a/seqnado/workflow/config/preset_genomes.json
+++ b/seqnado/workflow/config/preset_genomes.json
@@ -4,14 +4,16 @@
         "star_index": "/ceph/project/milne_group/shared/seqnado_reference/dm6/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/dm6/UCSC/sequence/dm6.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/dm6/UCSC/genes/dm6.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/dm6/dm6-blacklist.v2.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/dm6/dm6-blacklist.v2.bed.gz",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/dm6/UCSC/sequence/dm6.fa"
     },
     "hg19": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/hg19/UCSC/bt2_index/hg19",
         "star_index": "/ceph/project/milne_group/shared/seqnado_reference/hg19/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg19/UCSC/sequence/hg19.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg19/UCSC/genes/hg19.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg19/hg19-blacklist.v2.bed.gz "
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg19/hg19-blacklist.v2.bed.gz",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg19/UCSC/sequence/hg19.fa"
     },
     "hg38": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/hg38/UCSC/bt2_index/hg38",
@@ -19,48 +21,59 @@
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/UCSC/sequence/hg38.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg38/UCSC/genes/hg38.ncbiRefSeq.gtf",
         "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38-blacklist.v2.bed.gz",
-        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed"
+        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg38/UCSC/sequence/hg38.fa"
     },
     "hg38_dm6": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/UCSC/bt2_index/hg38_dm6",
         "star_index": "NA",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/UCSC/sequence/hg38_dm6.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/UCSC/genes/hg38_dm6.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/hg38_dm6-blacklist.v2.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/hg38_dm6-blacklist.v2.bed.gz",
+        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg38_dm6/UCSC/sequence/hg38_dm6.fa"
     },
     "hg38_ecoli": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/hg38_ecoli/bt2_index/hg38_ecoli",
         "star_index": "NA",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg38_ecoli/sequence/hg38_ecoli.fa.fai",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg38/UCSC/genes/hg38.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38-blacklist.v2.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38-blacklist.v2.bed.gz",
+        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg38_ecoli/sequence/hg38_ecoli.fa"
     },
     "hg38_mm39": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/bt2_index/hg38_mm39",
         "star_index": "NA",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/sequence/hg38_mm39.fa.fai",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/genes/hg38_mm39.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/hg38_mm39-blacklist.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/hg38_mm39-blacklist.bed.gz",
+        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg38_mm39/sequence/hg38_mm39.fa"
     },
     "hg38_spikein": {
         "bt2_index": "NA",
         "star_index": "/ceph/project/milne_group/shared/seqnado_reference/hg38_spikein/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/hg38_spikein/hg38_spikein.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/hg38_spikein/UCSC/genes/hg38_spikein_transcripts.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38-blacklist.v2.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38-blacklist.v2.bed.gz",
+        "genes": "/ceph/project/milne_group/shared/seqnado_reference/hg38/hg38_genes.bed",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/hg38_spikein/UCSC/sequence/hg38_spikein.fa"
     },
     "mm10": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/mm10/UCSC/bt2_index/mm10",
         "star_index": "/ceph/project/milne_group/shared/seqnado_reference/mm10/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/mm10/UCSC/sequence/mm10.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/mm10/UCSC/genes/mm10.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/mm10/mm10-blacklist.v2.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/mm10/mm10-blacklist.v2.bed.gz",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/mm10/UCSC/sequence/mm10.fa"
     },
     "mm39": {
         "bt2_index": "/ceph/project/milne_group/shared/seqnado_reference/mm39/UCSC/bt2_index/mm39",
         "star_index": "/ceph/project/milne_group/shared/seqnado_reference/mm39/UCSC/STAR_2.7.10b",
         "chromosome_sizes": "/ceph/project/milne_group/shared/seqnado_reference/mm39/UCSC/sequence/mm39.chrom.sizes",
         "gtf": "/ceph/project/milne_group/shared/seqnado_reference/mm39/UCSC/genes/mm39.ncbiRefSeq.gtf",
-        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/mm39/mm10-blacklist.v2.Liftover.mm39.bed.gz"
+        "blacklist": "/ceph/project/milne_group/shared/seqnado_reference/mm39/mm10-blacklist.v2.Liftover.mm39.bed.gz",
+        "fasta": "/ceph/project/milne_group/shared/seqnado_reference/mm39/UCSC/sequence/mm39.fa"
     }
 }

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -158,6 +158,7 @@ def blacklist(genome_path):
 
     return blacklist_path
 
+
 @pytest.fixture(scope="function")
 def meth_files(genome_path):
     meth_fasta = genome_path / "chr21_meth.fa"
@@ -253,7 +254,9 @@ def run_directory(tmpdir_factory, assay):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def run_init(index, chromsizes, gtf, blacklist, run_directory, assay, monkeypatch):
+def run_init(
+    index, chromsizes, gtf, blacklist, run_directory, assay, monkeypatch, meth_files
+):
     """
     Runs seqnado-init before each test inside the test directory.
     Ensures genome_config.json is correctly written.
@@ -284,6 +287,8 @@ def run_init(index, chromsizes, gtf, blacklist, run_directory, assay, monkeypatc
             "star_index": "NA",
             "bt2_index": str(index),
         }
+
+    meth_fasta, _ = meth_files
     genome_config_dict = {
         "hg38": {
             "star_index": index_dict["star_index"],
@@ -291,6 +296,8 @@ def run_init(index, chromsizes, gtf, blacklist, run_directory, assay, monkeypatc
             "chromosome_sizes": str(chromsizes),
             "gtf": str(gtf),
             "blacklist": str(blacklist),
+            "genes": "",
+            "fasta": str(meth_fasta) if assay == "meth" else "",
         }
     }
     with open(genome_config_file, "w") as f:
@@ -315,7 +322,9 @@ def user_inputs(test_data_path, assay, assay_type, plot_bed, meth_files):
         "Do you have spikein? (yes/no)": "yes" if "rx" in assay else "no",
         "Duplicates removal method:": "picard",
         "Fastqscreen config path:": "/dummy/fastqscreen.conf",
-        "Generate consensus counts from Design merge column? (yes/no)": "yes" if assay in ["atac", "chip-rx"] else "no",
+        "Generate consensus counts from Design merge column? (yes/no)": "yes"
+        if assay in ["atac", "chip-rx"]
+        else "no",
         "Generate GEO submission files?": "yes" if assay in ["chip", "rna"] else "no",
         "Genome?": "hg38",
         "Make Bigwigs?": "yes",
@@ -323,10 +332,16 @@ def user_inputs(test_data_path, assay, assay_type, plot_bed, meth_files):
         "Make UCSC hub?": "yes",
         "Methylation assay:": "taps",
         "Normalisation method:": "orlando",
-        "Path to bed file with coordinates for plotting": str(plot_bed) if not assay == "snp" else "",
+        "Path to bed file with coordinates for plotting": str(plot_bed)
+        if not assay == "snp"
+        else "",
         "Path to bed file with genes.": "",
-        "Path to reference fasta index:": "dummy_ref.fasta.fai" if not assay == "meth" else str(meth_fasta_fai),
-        "Path to reference fasta:": "dummy_ref.fasta" if not assay == "meth" else str(meth_fasta),
+        "Path to reference fasta index:": "dummy_ref.fasta.fai"
+        if not assay == "meth"
+        else str(meth_fasta_fai),
+        "Path to reference fasta:": "dummy_ref.fasta"
+        if not assay == "meth"
+        else str(meth_fasta),
         "Path to SNP database:": "dummy_snp_db",
         "Peak calling method:": "lanceotron",
         "Perform fastqscreen?": "no",


### PR DESCRIPTION
This pull request includes several changes to the `seqnado` project, focusing on enhancing the genome configuration and workflow configuration, as well as updating the test pipelines to accommodate these changes. The most important changes include adding new optional fields for genome and workflow configurations, updating the default genome configuration files, and modifying the test pipeline to handle the new configuration fields.

Enhancements to genome and workflow configurations:

* Added `fasta` as an optional field in the `GenomeConfig` class in `seqnado/config.py` to specify the path to the reference fasta file.
* Added methylation-specific fields `call_methylation` and `methylation_assay` to the `WorkflowConfig` class in `seqnado/config.py` to support methylation assays.

Updates to default genome configuration files:

* Updated `genomes_template.json` to include `fasta` and `genes` fields for each genome configuration.
* Updated `preset_genomes.json` to include the `fasta` field for each genome configuration.

Modifications to test pipelines:

* Updated the `get_conditional_features` function in `seqnado/config.py` to use the `fasta` field from the genome configuration if available, otherwise prompt the user for the path.
* Modified `tests/test_pipelines.py` to include the `fasta` field in the genome configuration and handle methylation-specific files in the test setup and user inputs. [[1]](diffhunk://#diff-5053985009d18dfbd4317f5bd7ee7e7dcd7957ec0f934a5f9e24dc073b20df36L256-R259) [[2]](diffhunk://#diff-5053985009d18dfbd4317f5bd7ee7e7dcd7957ec0f934a5f9e24dc073b20df36R290-R300) [[3]](diffhunk://#diff-5053985009d18dfbd4317f5bd7ee7e7dcd7957ec0f934a5f9e24dc073b20df36L318-R344)