### PR TITLE
Fix seqnado report

### DIFF
--- a/seqnado/config.py
+++ b/seqnado/config.py
@@ -68,6 +68,7 @@ class WorkflowConfig(BaseModel):
     # SNP-Specific
     call_snps: bool = False
     snp_calling_method: Literal["bcftools", "deepvariant", "False"] = "False"
+    annotate_snps: bool = False
     snp_database: Optional[str] = None
 
     # MCC-Specific
@@ -296,10 +297,11 @@ def get_conditional_features(assay: str, genome_config: dict) -> dict:
     if assay == "snp":
         features["call_snps"] = get_user_input("Call SNPs?", default="no", is_boolean=True)
         if features["call_snps"]:
-            features["snp_calling_method"] = get_user_input("SNP caller:", choices=["bcftools", "deepvariant"], default="bcftools")
             features["fasta"] = genome_config.fasta if genome_config.fasta else get_user_input("Path to reference fasta:", default='no')
             features["fasta_index"] = get_user_input("Path to reference fasta index:", default="path/to/reference.fasta.fai", is_path=True)
-            features["snp_database"] = get_user_input("Path to SNP database:", default="path/to/snp_database", is_path=True)
+            features["annotate_snps"] = get_user_input("Annotate SNPs?", default="no", is_boolean=True)
+            if features["annotate_snps"]:
+                features["snp_database"] = get_user_input("Path to SNP database:", default="path/to/snp_database", is_path=True)
     
     # Methylation Calling
     if assay == "meth":

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1933,8 +1933,6 @@ class METHOutput(Output):
 
     @property
     def methylation_bias(self) -> List[str]:
-        """
-        Get the methylation bias files. and seqnado_output/methylation/methylation_conversion.tsv"""
         if self.call_methylation:
             return expand(
                 "seqnado_output/methylation/methyldackel/bias/{sample}_{genome}.txt",

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1407,7 +1407,6 @@ class PeakCallingFiles(BaseModel):
 class HeatmapFiles(BaseModel):
     assay: Literal["ChIP", "ATAC", "RNA", "CUT&TAG"]
     make_heatmaps: bool = False
-    make_heatmaps: bool = False
 
     @property
     def heatmap_files(self) -> List[str]:
@@ -1858,10 +1857,6 @@ class SNPOutput(Output):
         else:
             return []
 
-    @property
-    def peaks(self):
-        return []
-
     @computed_field
     @property
     def files(self) -> List[str]:
@@ -1874,7 +1869,6 @@ class SNPOutput(Output):
         )
 
         for file_list in (
-            self.snp_files,
             self.design,
         ):
             if file_list:
@@ -1883,6 +1877,9 @@ class SNPOutput(Output):
         if self.call_snps:
             files.append(self.snp_files)
 
+        if self.annotate_snps:
+            files.append(self.anno_snp_files)
+        print(files)
         return files
 
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1879,7 +1879,7 @@ class SNPOutput(Output):
 
         if self.annotate_snps:
             files.append(self.anno_snp_files)
-        print(files)
+
         return files
 
 

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1830,14 +1830,9 @@ class IPOutput(NonRNAOutput):
 class SNPOutput(Output):
     assay: Literal["SNP"]
     call_snps: bool = False
+    annotate_snps: bool = False
     sample_names: List[str]
     make_ucsc_hub: bool = False
-    snp_calling_method: Optional[
-        Union[
-            Literal["bcftools", "deepvariant", False],
-            List[Literal["bcftools", "deepvariant"]],
-        ]
-    ] = None
 
     @property
     def design(self):
@@ -1847,9 +1842,18 @@ class SNPOutput(Output):
     def snp_files(self) -> List[str]:
         if self.call_snps:
             return expand(
-                "seqnado_output/variant/{method}/{sample}.vcf.gz",
+                "seqnado_output/variant/{sample}.vcf.gz",
                 sample=self.sample_names,
-                method=self.snp_calling_method,
+            )
+        else:
+            return []
+    
+    @property
+    def anno_snp_files(self) -> List[str]:
+        if self.annotate_snps:
+            return expand(
+                "seqnado_output/variant/{sample}.anno.vcf.gz",
+                sample=self.sample_names,
             )
         else:
             return []

--- a/seqnado/workflow/config/config.yaml.jinja
+++ b/seqnado/workflow/config/config.yaml.jinja
@@ -32,8 +32,9 @@ shift_atac_reads: "{{shift_atac_reads}}"
 {% endif %}
 
 
-{% if spikein %}
+
 spikein: "{{spikein}}"
+{% if spikein %}
 spikein_options:
     normalisation_method: "{{normalisation_method}}"
     reference_genome: "{{reference_genome}}"

--- a/seqnado/workflow/config/config.yaml.jinja
+++ b/seqnado/workflow/config/config.yaml.jinja
@@ -66,7 +66,7 @@ methylation_assay: "{{methylation_assay}}"
 
 {% if assay == "snp" %}
 call_snps: "{{call_snps}}"
-snp_calling_method: "{{snp_calling_method}}"
+annotate_snps: "{{annotate_snps}}"
 snp_database: "{{snp_database}}"
 {% endif %}
 

--- a/seqnado/workflow/rules/alignment_post_processing.smk
+++ b/seqnado/workflow/rules/alignment_post_processing.smk
@@ -89,7 +89,7 @@ if config["remove_pcr_duplicates_method"] == "picard":
         output:
             bam=temp("seqnado_output/aligned/duplicates_removed/{sample}.bam"),
             bai=temp("seqnado_output/aligned/duplicates_removed/{sample}.bam.bai"),
-            metrics=temp("seqnado_output/aligned/duplicates_removed/{sample}.metrics"),
+            metrics="seqnado_output/qc/library_complexity/{sample}.metrics",
             read_log=temp("seqnado_output/qc/alignment_post_process/{sample}_remove_duplicates.tsv"),
         threads: 8
         params:
@@ -103,6 +103,7 @@ if config["remove_pcr_duplicates_method"] == "picard":
         mv seqnado_output/aligned/duplicates_removed/{wildcards.sample}.bai {output.bai} &&
         echo -e "duplicate removal\t$(samtools view -c {output.bam})" >> {output.read_log} 2>&1 | tee -a {log}
         """
+
 elif config["remove_pcr_duplicates_method"] == "samtools":
     rule remove_duplicates_using_samtools:
         input:

--- a/seqnado/workflow/rules/alignment_post_processing.smk
+++ b/seqnado/workflow/rules/alignment_post_processing.smk
@@ -8,7 +8,7 @@ rule sort_bam:
         bam=temp("seqnado_output/aligned/sorted/{sample}.bam"),
         read_log=temp("seqnado_output/qc/alignment_post_process/{sample}_sort.tsv"),
     resources:
-        mem=lambda wildcards, attempt: define_memory_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
+        mem=lambda wildcards, attempt: define_memory_requested(initial_value=6, attempts=attempt, scale=SCALE_RESOURCES),
         runtime=lambda wildcards, attempt: define_time_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
     threads: config["samtools"]["threads"]
     log: "seqnado_output/logs/alignment_post_process/{sample}_sort.log",

--- a/seqnado/workflow/rules/exogenous_norm.smk
+++ b/seqnado/workflow/rules/exogenous_norm.smk
@@ -16,8 +16,11 @@ use rule align_single as align_single_spikein with:
         mem=lambda wildcards, attempt: define_memory_requested(initial_value=8, attempts=attempt, scale=SCALE_RESOURCES),
         runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
 
+ruleorder: align_paired > align_paired_spikein > align_single > align_single_spikein 
 
-ruleorder: align_paired_spikein> align_paired > align_single_spikein > align_single
+if config["spikein"]:
+    ruleorder: align_paired_spikein> align_paired > align_single_spikein > align_single
+
 
 use rule sort_bam as sort_bam_spikein with:
     input:

--- a/seqnado/workflow/rules/exogenous_norm.smk
+++ b/seqnado/workflow/rules/exogenous_norm.smk
@@ -17,7 +17,7 @@ use rule align_single as align_single_spikein with:
         runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
 
 
-ruleorder: align_paired > align_paired_spikein > align_single > align_single_spikein 
+ruleorder: align_paired_spikein> align_paired > align_single_spikein > align_single
 
 use rule sort_bam as sort_bam_spikein with:
     input:

--- a/seqnado/workflow/rules/fastq_screen.smk
+++ b/seqnado/workflow/rules/fastq_screen.smk
@@ -8,7 +8,7 @@ rule fastq_screen_paired:
     output:
         fq_screen=temp("seqnado_output/qc/fastq_screen/{sample}_{read}_screen.html"),
         fq_screen_png=temp("seqnado_output/qc/fastq_screen/{sample}_{read}_screen.png"),
-        fq_screen_txt=temp("seqnado_output/qc/fastq_screen/{sample}_{read}_screen.txt"),
+        fq_screen_txt="seqnado_output/qc/fastq_screen/{sample}_{read}_screen.txt",
     params:
         outdir=temp("seqnado_output/qc/fastq_screen"),
         conf=config["fastq_screen_config"],

--- a/seqnado/workflow/rules/fastq_screen.smk
+++ b/seqnado/workflow/rules/fastq_screen.smk
@@ -12,13 +12,14 @@ rule fastq_screen_paired:
     params:
         outdir=temp("seqnado_output/qc/fastq_screen"),
         conf=config["fastq_screen_config"],
-    threads: config.get("bowtie2")["threads"] if config.get("bowtie2") else 4,
+    threads: 4,
     resources:
-        mem=lambda wildcards, attempt: f"{16 * 2**attempt}GB",
+        mem=lambda wildcards, attempt: define_memory_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
+        runtime=lambda wildcards, attempt: define_time_requested(initial_value=1, attempts=attempt, scale=SCALE_RESOURCES),
     log:
         "seqnado_output/logs/fastq_screen/{sample}_{read}.log",
     shell:
-        """ fastq_screen --conf {params.conf} --threads {threads} --subset 10000 --aligner bowtie2 --threads 8 {input.fq}  --outdir {params.outdir} > {log} 2>&1 """
+        """ fastq_screen --conf {params.conf} --threads {threads} --subset 10000 --aligner bowtie2 --threads {threads} {input.fq}  --outdir {params.outdir} > {log} 2>&1 """
 
 
 use rule fastq_screen_paired as fastq_screen_single with:
@@ -31,35 +32,4 @@ use rule fastq_screen_paired as fastq_screen_single with:
     log:
         "seqnado_output/logs/fastq_screen/{sample}.log",
 
-
-def get_fastqscreen_files(*args, **kwargs):
-    """Return a list of fastq_screen files for a given sample name."""
-    from pathlib import Path
-
-    fastq_dir = Path("seqnado_output/fastqs/")
-    fastqscreen_dir = Path("seqnado_output/qc/fastq_screen")
-    fastqscreen_files = []
-    for fq in fastq_dir.glob("*.fastq.gz"):
-        base_name = fq.stem.split(".fastq")[0]
-        for ext in ["html", "png", "txt"]:
-            fastqscreen_file = fastqscreen_dir / f"{base_name}_screen.{ext}".replace(
-                " ", ""
-            )
-            fastqscreen_files.append(str(fastqscreen_file))
-    return fastqscreen_files
-
-
-rule multiqc_fastqscreen:
-    input:
-        get_fastqscreen_files,
-    output:
-        "seqnado_output/qc/full_fastqscreen_report.html",
-    log:
-        "seqnado_output/logs/multiqc_fastqscreen.log",
-    resources:
-        mem=lambda wildcards, attempt: define_memory_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
-    shell:
-        "multiqc -o seqnado_output/qc -n full_fastqscreen_report.html --force seqnado_output/qc/fastq_screen > {log} 2>&1"
-
-
-ruleorder: fastq_screen_paired > fastq_screen_single > multiqc_fastqscreen
+ruleorder: fastq_screen_paired > fastq_screen_single 

--- a/seqnado/workflow/rules/peak_call_chip.smk
+++ b/seqnado/workflow/rules/peak_call_chip.smk
@@ -164,7 +164,7 @@ rule lanceotron_no_input:
     output:
         peaks="seqnado_output/peaks/lanceotron/{sample}_{treatment}.bed",
     log:
-        "seqnado_output/logs/lanceotron/{sample}_{treatment}.bed",
+        "seqnado_output/logs/lanceotron/{sample}_{treatment}.log",
     params:
         options=check_options(config["lanceotron"]["callpeak"]),
         outdir=lambda wc, output: os.path.dirname(output.peaks),

--- a/seqnado/workflow/rules/peak_call_other.smk
+++ b/seqnado/workflow/rules/peak_call_other.smk
@@ -24,7 +24,7 @@ rule macs2_no_input:
         mem=lambda wildcards, attempt: define_memory_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
         runtime=lambda wildcards, attempt: define_time_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
     log:
-        "seqnado_output/logs/macs/{sample}.bed",
+        "seqnado_output/logs/macs/{sample}.log",
     shell:
         """
         macs2 callpeak -t {input.treatment} -n {params.basename} -f BAMPE {params.options} > {log} 2>&1 &&
@@ -38,7 +38,7 @@ rule homer_no_input:
     output:
         peaks="seqnado_output/peaks/homer/{sample}.bed",
     log:
-        "seqnado_output/logs/homer/{sample}.bed",
+        "seqnado_output/logs/homer/{sample}.log",
     params:
         options=check_options(config["homer"]["findpeaks"]),
     threads: 1
@@ -59,7 +59,7 @@ rule lanceotron_no_input:
     output:
         peaks="seqnado_output/peaks/lanceotron/{sample}.bed",
     log:
-        "seqnado_output/logs/lanceotron/{sample}.bed",
+        "seqnado_output/logs/lanceotron/{sample}.log",
     params:
         options=check_options(config["lanceotron"]["callpeak"]),
         outdir=lambda wc, output: os.path.dirname(output.peaks),

--- a/seqnado/workflow/rules/qc.smk
+++ b/seqnado/workflow/rules/qc.smk
@@ -17,7 +17,6 @@ rule fastqc_raw_paired:
     params:
         extra="--quiet",
         output_dir="seqnado_output/qc/fastqc_raw/",
-        temp_prefix="seqnado_output/qc/fastqc_raw/{sample}",
     threads: 1
     resources:
         mem=lambda wildcards, attempt: define_memory_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
@@ -39,13 +38,13 @@ rule fastqc_raw_single:
     params:
         extra="--quiet",
         output_dir="seqnado_output/qc/fastqc_raw/",
-        temp_prefix="seqnado_output/qc/fastqc_raw/{sample}",
     log:
         "seqnado_output/logs/fastqc_raw/{sample}.log",
     shell:
         """
         fastqc -o {params.output_dir} {input} > {log} 2>&1
         """
+
 
 use rule fastqc_raw_paired as fastqc_trimmed_paired with:
     input:
@@ -59,7 +58,6 @@ use rule fastqc_raw_paired as fastqc_trimmed_paired with:
     params:
         extra="--quiet",
         output_dir="seqnado_output/qc/fastqc_trimmed/",
-        temp_prefix="seqnado_output/qc/fastqc_trimmed/{sample}",
     log:
         "seqnado_output/logs/fastqc_trimmed/{sample}.log",
 
@@ -73,7 +71,6 @@ use rule fastqc_raw_single as fastqc_trimmed_single with:
     params:
         extra="--quiet",
         output_dir="seqnado_output/qc/fastqc_trimmed/",
-        temp_prefix="seqnado_output/qc/fastqc_trimmed/{sample}",
     log:
         "seqnado_output/logs/fastqc_trimmed/{sample}.log",
 
@@ -85,7 +82,7 @@ use rule fastqc_raw_single as fastqc_trimmed_single with:
 rule multiqc_library_complexity:
     input:
         expand(
-            "seqnado_output/aligned/duplicates_removed/{sample}.metrics",
+            "seqnado_output/qc/library_complexity/{sample}.metrics",
             sample=SAMPLE_NAMES,
         ),
     output:
@@ -258,7 +255,7 @@ def get_fastq_screen_all(wildcards):
 def get_library_complexity_qc(wildcards):
     if config["library_complexity"]:
         return expand(
-            "seqnado_output/aligned/duplicates_removed/{sample}.metrics",
+            "seqnado_output/qc/library_complexity/{sample}.metrics",
             sample=SAMPLE_NAMES,
         )
     else:
@@ -329,7 +326,7 @@ def get_counts_files(wildcards):
 def get_snp_qc(wildcards):
     if ASSAY == "SNP" and config["call_snps"]:
         return expand(
-            "seqnado_output/variant/bcftools/{sample}_filtered.anno.vcf.gz",
+            "seqnado_output/variant/{sample}.anno.vcf.gz",
             sample=SAMPLE_NAMES,
         )
     else:

--- a/seqnado/workflow/rules/qc.smk
+++ b/seqnado/workflow/rules/qc.smk
@@ -20,8 +20,8 @@ rule fastqc_raw_paired:
         temp_prefix="seqnado_output/qc/fastqc_raw/{sample}",
     threads: 1
     resources:
-        mem="1.5GB",
-         runtime=lambda wildcards, attempt: define_time_requested(initial_value=1, attempts=attempt, scale=SCALE_RESOURCES),
+        mem=lambda wildcards, attempt: define_memory_requested(initial_value=2, attempts=attempt, scale=SCALE_RESOURCES),
+        runtime=lambda wildcards, attempt: define_time_requested(initial_value=1, attempts=attempt, scale=SCALE_RESOURCES),
     log:
         "seqnado_output/logs/fastqc_raw/{sample}.log",
     shell:

--- a/seqnado/workflow/rules/qc.smk
+++ b/seqnado/workflow/rules/qc.smk
@@ -326,12 +326,12 @@ def get_counts_files(wildcards):
 def get_snp_qc(wildcards):
     if ASSAY == "SNP" and config["call_snps"]:
         return expand(
-            "seqnado_output/variant/{sample}.vcf.gz",
+            "seqnado_output/variant/bcftools/{sample}.stats.txt",
             sample=SAMPLE_NAMES,
         )
     if ASSAY == "SNP" and config["annotate_snps"]:
         return expand(
-            "seqnado_output/variant/{sample}.anno.vcf.gz",
+            "seqnado_output/variant/bcftools/{sample}.anno.stats.txt",
             sample=SAMPLE_NAMES,
         )
     else:

--- a/seqnado/workflow/rules/qc.smk
+++ b/seqnado/workflow/rules/qc.smk
@@ -326,6 +326,11 @@ def get_counts_files(wildcards):
 def get_snp_qc(wildcards):
     if ASSAY == "SNP" and config["call_snps"]:
         return expand(
+            "seqnado_output/variant/{sample}.vcf.gz",
+            sample=SAMPLE_NAMES,
+        )
+    if ASSAY == "SNP" and config["annotate_snps"]:
+        return expand(
             "seqnado_output/variant/{sample}.anno.vcf.gz",
             sample=SAMPLE_NAMES,
         )

--- a/seqnado/workflow/rules/variant.smk
+++ b/seqnado/workflow/rules/variant.smk
@@ -18,7 +18,7 @@ rule bcftools_call_snp:
         "seqnado_output/logs/variant/{sample}.log",
     shell:"""
     bcftools mpileup --threads {threads} -Ou -f {params.fasta} {input.bam} | bcftools call --threads {threads} -mv -Oz -o {output.vcf} > {log} 2>&1 &&
-    tabix -f {input.vcf} > {output.idx} 
+    tabix -f {output.vcf} > {output.idx} 
     """
 
 

--- a/seqnado/workflow/rules/variant.smk
+++ b/seqnado/workflow/rules/variant.smk
@@ -19,7 +19,7 @@ rule bcftools_call_snp:
     shell:"""
     bcftools mpileup --threads {threads} -Ou -f {params.fasta} {input.bam} | bcftools call --threads {threads} -mv -Oz -o {output.vcf} > {log} 2>&1 &&
     tabix -f {output.vcf} > {output.idx} &&
-    bcftools stats -F {params.fasta} -s - {input.vcf} > {output.stats}
+    bcftools stats -F {params.fasta} -s - {output.vcf} > {output.stats}
     """
 
 rule bcftools_annotate:
@@ -40,7 +40,7 @@ rule bcftools_annotate:
     log:
         "seqnado_output/logs/variant/{sample}_anno.log",
     shell:"""
-    bcftools annotate --threads 16 -c ID -a {params.dbsnp} {input.vcf} > {output.vcf} 2> {log} &&
+    bcftools annotate --threads 16 -c ID -a {params.dbsnp} {output.vcf} > {output.vcf} 2> {log} &&
     tabix -f {output.vcf} > {output.idx} &&
-    bcftools stats -F {params.fasta} -s - {input.vcf} > {output.stats}
+    bcftools stats -F {params.fasta} -s - {output.vcf} > {output.stats}
     """

--- a/seqnado/workflow/rules/variant.smk
+++ b/seqnado/workflow/rules/variant.smk
@@ -5,7 +5,7 @@ if config.get("call_snps"):
             bam="seqnado_output/aligned/{sample}.bam",
             bai="seqnado_output/aligned/{sample}.bam.bai",
         output:
-            vcf="seqnado_output/variant/bcftools/{sample}.vcf.gz",
+            vcf="seqnado_output/variant/{sample}.vcf.gz",
         params:
             fasta=config["fasta"],
             faidx=config["fasta_index"],
@@ -14,7 +14,7 @@ if config.get("call_snps"):
             runtime=lambda wildcards, attempt: f"{5 * 2 ** (attempt - 1)}h",
         threads: config["bcftools"]["threads"]
         log:
-            "seqnado_output/logs/variant/bcftools/bcftools/{sample}.log",
+            "seqnado_output/logs/variant/{sample}.log",
         shell:
             "bcftools mpileup --threads {threads} -Ou -f {params.fasta} {input.bam} | bcftools call --threads {threads} -mv -Oz -o {output.vcf} > {log} 2>&1"
 
@@ -22,60 +22,19 @@ if config.get("call_snps"):
         input:
             vcf=rules.bcftools_call_snp.output.vcf,
         output:
-            vcf="seqnado_output/variant/bcftools/{sample}_filtered.vcf.gz.tbi",
+            vcf="seqnado_output/variant/{sample}.vcf.gz.tbi",
         shell:
             "tabix -f {input.vcf} > {output.vcf}"
 
-    
-    rule bcftools_stats:
-        input:
-            vcf=rules.bcftools_call_snp.output.vcf,
-        output:
-            stats="seqnado_output/variant/bcftools/{sample}_filtered.stats.txt",
-        params:
-            fasta=config["fasta"],
-        shell:
-            "bcftools stats -F {params.fasta} -s - {input.vcf} > {output.stats}"
-
-    rule bcftools_stats_plot:
-        input:
-            stats=rules.bcftools_stats.output.stats,
-        output:
-            summary="seqnado_output/variant/bcftools/{sample}_summary.pdf",
-        params:
-            fasta=config["fasta"],
-            out_dir="seqnado_output/variant/bcftools/",
-        shell:
-            "plot-vcfstats -p {params.out_dir} {input.stats}"
 
     rule bcftools_annotate:
         input:
             vcf=rules.bcftools_call_snp.output.vcf,
             idx=rules.index_snp.output.vcf,
         output:
-            vcf="seqnado_output/variant/bcftools/{sample}_filtered.anno.vcf.gz",
+            vcf="seqnado_output/variant/{sample}.anno.vcf.gz",
         params:
             dbsnp=config["snp_database"],
         threads: 16
         shell:
             "bcftools annotate --threads 16 -c ID -a {params.dbsnp} {input.vcf} > {output.vcf}"
-
-    # rule bcftools_split_multiallelic:
-    #     input:
-    #         vcf=rules.bcftools_call_snp.output.vcf,
-    #     output:
-    #         vcf="seqnado_output/variant/bcftools/{sample}_splitmultiallelic.vcf.gz",
-    #     shell:
-    #         "bcftools norm -m -any {input.vcf} -o {output.vcf} -Oz"
-
-    # rule bcftools_filter_snp:
-    #     input:
-    #         vcf=rules.bcftools_split_multiallelic.output.vcf,
-    #     output:
-    #         vcf="seqnado_output/variant/bcftools/{sample}_filtered.vcf.gz",
-    #     params:
-    #         options=check_options(config["bcftools"]["options"]),
-    #     shell:
-    #         """bcftools view {params.options} -o {output.vcf} {input.vcf}"""
-
-

--- a/seqnado/workflow/rules/variant.smk
+++ b/seqnado/workflow/rules/variant.smk
@@ -1,40 +1,38 @@
-if config.get("call_snps"):
-
-    rule bcftools_call_snp:
-        input:
-            bam="seqnado_output/aligned/{sample}.bam",
-            bai="seqnado_output/aligned/{sample}.bam.bai",
-        output:
-            vcf="seqnado_output/variant/{sample}.vcf.gz",
-        params:
-            fasta=config["fasta"],
-            faidx=config["fasta_index"],
-        resources:
-            mem=lambda wildcards, attempt: f"{10 * 2 ** (attempt -1)}GB",
-            runtime=lambda wildcards, attempt: f"{5 * 2 ** (attempt - 1)}h",
-        threads: config["bcftools"]["threads"]
-        log:
-            "seqnado_output/logs/variant/{sample}.log",
-        shell:
-            "bcftools mpileup --threads {threads} -Ou -f {params.fasta} {input.bam} | bcftools call --threads {threads} -mv -Oz -o {output.vcf} > {log} 2>&1"
-
-    rule index_snp:
-        input:
-            vcf=rules.bcftools_call_snp.output.vcf,
-        output:
-            vcf="seqnado_output/variant/{sample}.vcf.gz.tbi",
-        shell:
-            "tabix -f {input.vcf} > {output.vcf}"
 
 
-    rule bcftools_annotate:
-        input:
-            vcf=rules.bcftools_call_snp.output.vcf,
-            idx=rules.index_snp.output.vcf,
-        output:
-            vcf="seqnado_output/variant/{sample}.anno.vcf.gz",
-        params:
-            dbsnp=config["snp_database"],
-        threads: 16
-        shell:
-            "bcftools annotate --threads 16 -c ID -a {params.dbsnp} {input.vcf} > {output.vcf}"
+rule bcftools_call_snp:
+    input:
+        bam="seqnado_output/aligned/{sample}.bam",
+        bai="seqnado_output/aligned/{sample}.bam.bai",
+    output:
+        vcf="seqnado_output/variant/{sample}.vcf.gz",
+        idx="seqnado_output/variant/{sample}.vcf.gz.tbi",
+    params:
+        fasta=config["fasta"],
+        faidx=config["fasta_index"],
+    resources:
+        mem=lambda wildcards, attempt: f"{10 * 2 ** (attempt -1)}GB",
+        runtime=lambda wildcards, attempt: f"{5 * 2 ** (attempt - 1)}h",
+    threads: config["bcftools"]["threads"]
+    log:
+        "seqnado_output/logs/variant/{sample}.log",
+    shell:"""
+    bcftools mpileup --threads {threads} -Ou -f {params.fasta} {input.bam} | bcftools call --threads {threads} -mv -Oz -o {output.vcf} > {log} 2>&1
+    tabix -f {input.vcf} > {output.vcf}
+    """
+
+
+rule bcftools_annotate:
+    input:
+        vcf=rules.bcftools_call_snp.output.vcf,
+        idx=rules.bcftools_call_snp.output.idx,
+    output:
+        vcf="seqnado_output/variant/{sample}.anno.vcf.gz",
+        idx="seqnado_output/variant/{sample}.anno.vcf.gz.tbi",
+    params:
+        dbsnp=config["snp_database"],
+    threads: 16
+    shell:"""
+    bcftools annotate --threads 16 -c ID -a {params.dbsnp} {input.vcf} > {output.vcf}
+    bcftools index -f {output.vcf}
+    """

--- a/seqnado/workflow/scripts/alignment_stats.py
+++ b/seqnado/workflow/scripts/alignment_stats.py
@@ -38,6 +38,6 @@ if processed_data:
     stacked_df = pd.DataFrame(processed_data).T.fillna(0).reset_index()
     stacked_df.rename(columns={'index': 'sample'}, inplace=True)
     stacked_df.to_csv(snakemake.output[0], sep='\t', index=False)
-    logger.info(f"Stacked bar chart data written to {snakemake.output[0]}")
+    logger.info(f"Alignmetn data written to {snakemake.output[0]}")
 else:
     logger.warning("No valid input files found; no output written.")

--- a/seqnado/workflow/snakefile_meth
+++ b/seqnado/workflow/snakefile_meth
@@ -87,7 +87,6 @@ include: "rules/alignment_post_processing.smk"
 include: "rules/fastq_screen.smk"
 include: "rules/fastq_trim.smk"
 include: "rules/qc.smk"
-include: "rules/variant.smk"
 include: "rules/geo_submission.smk"
 include: "rules/meth_calling.smk"
 


### PR DESCRIPTION
This pull request introduces several changes to the `seqnado` project, focusing on SNP annotation functionality and various improvements to workflow configurations and resource management. The most important changes include adding SNP annotation options, updating memory and runtime configurations, and fixing file paths and logging.

### SNP Annotation Functionality:
* [`seqnado/config.py`](diffhunk://#diff-2d53a7a5c9fa2ba25d0279cb9bd1f156233bc2caf0cf48a5f281c08847810b57R71): Added `annotate_snps` option to `WorkflowConfig` and updated `get_conditional_features` to include user input for SNP annotation. [[1]](diffhunk://#diff-2d53a7a5c9fa2ba25d0279cb9bd1f156233bc2caf0cf48a5f281c08847810b57R71) [[2]](diffhunk://#diff-2d53a7a5c9fa2ba25d0279cb9bd1f156233bc2caf0cf48a5f281c08847810b57L299-R303)
* [`seqnado/design.py`](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1832-L1840): Added `annotate_snps` to `SNPOutput` and updated file generation methods to handle annotated SNPs. [[1]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1832-L1840) [[2]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690L1850-R1857) [[3]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1880-R1882)

### Workflow Configurations:
* [`seqnado/workflow/config/config.yaml.jinja`](diffhunk://#diff-32359961b8fb23358c8167c526b0971f4a4077edd0c24ce3e15bf1a464e811bdL68-R69): Updated configuration to include `annotate_snps` instead of `snp_calling_method`.

### Resource Management:
* [`seqnado/workflow/rules/alignment_post_processing.smk`](diffhunk://#diff-65fcc45fd79b55f2681b0d98c3189ad4fd7f86041f9caca6f710aa0d44479d34L11-R11): Increased memory allocation for sorting BAM files and updated file paths for PCR duplicate metrics. [[1]](diffhunk://#diff-65fcc45fd79b55f2681b0d98c3189ad4fd7f86041f9caca6f710aa0d44479d34L11-R11) [[2]](diffhunk://#diff-65fcc45fd79b55f2681b0d98c3189ad4fd7f86041f9caca6f710aa0d44479d34L92-R92)

### File Paths and Logging:
* [`seqnado/workflow/rules/fastq_screen.smk`](diffhunk://#diff-ece9eb94a4a3264ed177e5c95c0313c0210eedd643282856235639af84b8e250L11-R22): Fixed file paths for `fastq_screen` outputs and updated memory and runtime configurations.
* `seqnado/workflow/rules/peak_call_chip.smk` and `seqnado/workflow/rules/peak_call_other.smk`: Corrected log file extensions from `.bed` to `.log`. [[1]](diffhunk://#diff-5b569618c7236939092544fc42d9e467c40907ca827c7dacbaa38ac530730e93L167-R167) [[2]](diffhunk://#diff-d478bccd3cc40267602f94a284563836d3f61c204ca844651001967fe629b1cdL27-R27) [[3]](diffhunk://#diff-d478bccd3cc40267602f94a284563836d3f61c204ca844651001967fe629b1cdL41-R41) [[4]](diffhunk://#diff-d478bccd3cc40267602f94a284563836d3f61c204ca844651001967fe629b1cdL62-R62)

### Miscellaneous:
* Removed duplicate `make_heatmaps` attribute in `HeatmapFiles` class.
* Removed unnecessary `multiqc_fastqscreen` rule and its dependencies.