### PR TITLE
make ML datasets

### DIFF
--- a/.github/workflows/test_pipelines.yml
+++ b/.github/workflows/test_pipelines.yml
@@ -63,6 +63,8 @@ jobs:
             apptainer pull --force library://asmith151/seqnado/seqnado_report:latest
           elif [[ "${{ matrix.assay }}" == "meth" ]]; then
             apptainer pull --force library://cchahrou/seqnado/seqnado_meth.sif:latest
+          elif [[ "${{ matrix.assay }}" == "cat" ]]; then
+            apptainer pull --force library://cchahrou/seqnado/seqnado_quant:latest
           fi
 
       - name: Test ${{ matrix.test }} ${{ matrix.assay }}

--- a/seqnado/design.py
+++ b/seqnado/design.py
@@ -1524,10 +1524,13 @@ class Output(BaseModel):
     library_complexity: bool = False
 
     geo_submission_files: bool = False
-
+    
     perform_plotting: bool = False
     plotting_format: Literal["svg", "png", "pdf"] = "svg"
     plotting_coordinates: Optional[Union[str, pathlib.Path]] = None
+
+    make_dataset: bool = False
+
 
     # Correct plotting_coordinates type as it may be False
     @validator("plotting_coordinates", pre=True)
@@ -1615,6 +1618,22 @@ class Output(BaseModel):
             design=self.design_dataframe,
             config=self.config,
         )
+    @property
+    def dataset_files(self):
+        if not self.make_dataset:
+            return []
+
+        dataset_config = self.config.get("dataset", {})
+        use_regions = dataset_config.get("regions_bed")
+        use_bins = dataset_config.get("binsize")
+
+        if use_regions and str(use_regions).strip():
+            return ["seqnado_output/dataset/dataset_regions.h5ad"]
+        elif use_bins and str(use_bins).strip():
+            return ["seqnado_output/dataset/dataset_bins.h5ad"]
+        else:
+            return []
+
 
 
 class RNAOutput(Output):
@@ -1659,6 +1678,7 @@ class RNAOutput(Output):
             self.counts,
             self.design,
             self.plots,
+            self.dataset_files,
         ):
             if file_list:
                 files.extend(file_list)
@@ -1745,6 +1765,7 @@ class NonRNAOutput(Output):
             self.design,
             self.plots,
             self.merged_counts,
+            self.dataset_files,
         ):
             if file_list:
                 files.extend(file_list)
@@ -1815,6 +1836,7 @@ class IPOutput(NonRNAOutput):
             self.design,
             self.plots,
             self.merged_counts,
+            self.dataset_files,
         ):
             if file_list:
                 files.extend(file_list)

--- a/seqnado/workflow/config/config.yaml.jinja
+++ b/seqnado/workflow/config/config.yaml.jinja
@@ -93,7 +93,7 @@ plotting_genes: "{{plotting_genes}}"
 plotting_format: "svg"
 
 {% if assay in ["atac", "chip", "cat"] %}
-make_dataset: {{ make_dataset }}
+make_dataset: "{{ make_dataset }}"
 dataset:
   {% if regions_bed is not none %}
   regions_bed: "{{ regions_bed }}"

--- a/seqnado/workflow/config/config.yaml.jinja
+++ b/seqnado/workflow/config/config.yaml.jinja
@@ -92,6 +92,24 @@ plotting_coordinates: "{{plotting_coordinates}}"
 plotting_genes: "{{plotting_genes}}"
 plotting_format: "svg"
 
+{% if assay in ["atac", "chip", "cat"] %}
+make_dataset: {{ make_dataset }}
+dataset:
+  {% if regions_bed is not none %}
+  regions_bed: "{{ regions_bed }}"
+  {% else %}
+  regions_bed: ""
+  {% endif %}
+
+  {% if binsize is not none %}
+  binsize: {{ binsize }}
+  {% else %}
+  binsize: ""
+  {% endif %}
+{% else %}
+make_dataset: "False"
+{% endif %}
+
 #################################
 # Tool specific options         #
 #################################

--- a/seqnado/workflow/rules/dataset.smk
+++ b/seqnado/workflow/rules/dataset.smk
@@ -25,7 +25,7 @@ rule make_dataset_regions:
     resources:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
-    log: "seqnado_output/logs/dataset/make_dataset_regions.log",
+    container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
     shell:"""
     quantnado-make-dataset \
     --bigwig-dir {params.bigwig_dir} \
@@ -54,7 +54,7 @@ rule make_dataset_binsize:
     resources:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
-    log: "seqnado_output/logs/dataset/make_dataset_binsize.log",
+    container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
     shell:"""
     quantnado-make-dataset \
     --bigwig-dir {params.bigwig_dir} \

--- a/seqnado/workflow/rules/dataset.smk
+++ b/seqnado/workflow/rules/dataset.smk
@@ -1,0 +1,65 @@
+from seqnado.helpers import check_options, define_time_requested, define_memory_requested
+
+if ASSAY == "ChIP":
+    prefix = SAMPLE_NAMES_IP
+else:
+    prefix = SAMPLE_NAMES
+
+
+rule make_dataset_regions:
+    """Create a dataset from bigWig files using either a BED file."""
+    input:
+        bigwigs=expand(
+            "seqnado_output/bigwigs/deeptools/{method}/{sample}.bigWig",
+            method=get_scale_method(config) or "unscaled",
+            sample=prefix,
+        ),
+    output:
+        dataset="seqnado_output/dataset/dataset_regions.h5ad",
+    params:
+        bigwig_dir="seqnado_output/bigwigs/deeptools/unscaled/",
+        chromosome_sizes=config['genome']['chromosome_sizes'],
+        blacklist=check_options(config["blacklist"]),
+        regions=check_options(config["dataset"]["regions_bed"]),
+    threads: 1
+    resources:
+            mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
+            runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
+    log: "seqnado_output/logs/dataset/make_dataset_regions.log",
+    shell:"""
+    quantnado-make-dataset \
+    --bigwig-dir {params.bigwig_dir} \
+    --output-file {output.dataset} \
+    --chromsizes {params.chromosome_sizes} \
+    --regions {params.regions} \
+    --blacklist {params.blacklist} 
+    """
+
+rule make_dataset_binsize:
+    """Create a dataset from bigWig files using bin size."""
+    input:
+        bigwigs=expand(
+            "seqnado_output/bigwigs/deeptools/{method}/{sample}.bigWig",
+            method=get_scale_method(config) or "unscaled",
+            sample=prefix,
+        ),
+    output:
+        dataset="seqnado_output/dataset/dataset_bins.h5ad",
+    params:
+        bigwig_dir="seqnado_output/bigwigs/deeptools/unscaled/",
+        chromosome_sizes=config['genome']['chromosome_sizes'],
+        blacklist=check_options(config["blacklist"]),
+        binsize=check_options(config["dataset"]["binsize"]),
+    threads: 1
+    resources:
+            mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
+            runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
+    log: "seqnado_output/logs/dataset/make_dataset_binsize.log",
+    shell:"""
+    quantnado-make-dataset \
+    --bigwig-dir {params.bigwig_dir} \
+    --output-file {output.dataset} \
+    --chromsizes {params.chromosome_sizes} \
+    --binsize {params.binsize} \
+    --blacklist {params.blacklist}
+    """

--- a/seqnado/workflow/rules/dataset.smk
+++ b/seqnado/workflow/rules/dataset.smk
@@ -26,6 +26,7 @@ rule make_dataset_regions:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
     container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
+    log: "seqnado_output/logs/make_dataset_regions.log",
     shell:"""
     quantnado-make-dataset \
     --bigwig-dir {params.bigwig_dir} \
@@ -33,6 +34,7 @@ rule make_dataset_regions:
     --chromsizes {params.chromosome_sizes} \
     --regions {params.regions} \
     --blacklist {params.blacklist} 
+    --log-file {log}
     """
 
 rule make_dataset_binsize:
@@ -55,6 +57,7 @@ rule make_dataset_binsize:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
     container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
+    log: "seqnado_output/logs/make_dataset_binsize.log",
     shell:"""
     quantnado-make-dataset \
     --bigwig-dir {params.bigwig_dir} \
@@ -62,4 +65,5 @@ rule make_dataset_binsize:
     --chromsizes {params.chromosome_sizes} \
     --binsize {params.binsize} \
     --blacklist {params.blacklist}
+    --log-file {log}
     """

--- a/seqnado/workflow/rules/dataset.smk
+++ b/seqnado/workflow/rules/dataset.smk
@@ -23,7 +23,7 @@ rule make_dataset_regions:
         regions=check_options(config["dataset"]["regions_bed"]),
     threads: 1
     resources:
-            mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
+            mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
     container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
     shell:"""
@@ -52,7 +52,7 @@ rule make_dataset_binsize:
         binsize=check_options(config["dataset"]["binsize"]),
     threads: 1
     resources:
-            mem=lambda wildcards, attempt: define_memory_requested(initial_value=5, attempts=attempt, scale=SCALE_RESOURCES),
+            mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
     container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
     shell:"""

--- a/seqnado/workflow/rules/dataset.smk
+++ b/seqnado/workflow/rules/dataset.smk
@@ -25,7 +25,7 @@ rule make_dataset_regions:
     resources:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
-    container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
+    container: "library://cchahrou/seqnado/seqnado_quant:latest",
     log: "seqnado_output/logs/make_dataset_regions.log",
     shell:"""
     quantnado-make-dataset \
@@ -33,7 +33,7 @@ rule make_dataset_regions:
     --output-file {output.dataset} \
     --chromsizes {params.chromosome_sizes} \
     --regions {params.regions} \
-    --blacklist {params.blacklist} 
+    --blacklist {params.blacklist} \
     --log-file {log}
     """
 
@@ -56,7 +56,7 @@ rule make_dataset_binsize:
     resources:
             mem=lambda wildcards, attempt: define_memory_requested(initial_value=32, attempts=attempt, scale=SCALE_RESOURCES),
             runtime=lambda wildcards, attempt: define_time_requested(initial_value=4, attempts=attempt, scale=SCALE_RESOURCES),
-    container: "library://cchahrou/seqnado/seqnado_quant.sif:latest",
+    container: "library://cchahrou/seqnado/seqnado_quant:latest",
     log: "seqnado_output/logs/make_dataset_binsize.log",
     shell:"""
     quantnado-make-dataset \
@@ -64,6 +64,6 @@ rule make_dataset_binsize:
     --output-file {output.dataset} \
     --chromsizes {params.chromosome_sizes} \
     --binsize {params.binsize} \
-    --blacklist {params.blacklist}
+    --blacklist {params.blacklist} \
     --log-file {log}
     """

--- a/seqnado/workflow/snakefile_atac
+++ b/seqnado/workflow/snakefile_atac
@@ -76,6 +76,7 @@ include: "rules/hub.smk"
 include: "rules/geo_submission.smk"
 include: "rules/visualisation.smk"
 include: "rules/consensus_counts.smk"
+include: "rules/dataset.smk"
 
 rule all:
     input:

--- a/seqnado/workflow/snakefile_cat
+++ b/seqnado/workflow/snakefile_cat
@@ -81,6 +81,7 @@ include: "rules/hub.smk"
 include: "rules/geo_submission.smk"
 include: "rules/visualisation.smk"
 include: "rules/consensus_counts.smk"
+include: "rules/dataset.smk"
 
 
 if config.get("spikein"):

--- a/seqnado/workflow/snakefile_chip
+++ b/seqnado/workflow/snakefile_chip
@@ -81,7 +81,7 @@ include: "rules/hub.smk"
 include: "rules/geo_submission.smk"
 include: "rules/visualisation.smk"
 include: "rules/consensus_counts.smk"
-
+include: "rules/dataset.smk"
 
 if config.get("spikein"):
     ruleorder: move_ref_bam > align_paired > align_single

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -337,7 +337,7 @@ def user_inputs(test_data_path, assay, assay_type, plot_bed, genome_files, mcc_f
         "Call peaks?": "yes",
         "Call SNPs?": "yes" if assay == "snp" else "no",
         "Color by (for UCSC hub):": "samplename",
-        "Do you have spikein? (yes/no)": "yes" if "rx" in assay else "no",
+        "Do you have spikein?": "yes" if "rx" in assay else "no",
         "Duplicates removal method:": "picard",
         "Fastqscreen config path:": "/dummy/fastqscreen.conf",
         "Generate consensus counts from Design merge column? (yes/no)": "yes"
@@ -381,6 +381,10 @@ def user_inputs(test_data_path, assay, assay_type, plot_bed, genome_files, mcc_f
         if assay == "mcc"
         else "",
         "Resolution for MCC cooler files:": "100",
+        "Make dataset for ML?": "yes" if assay == "cat" else "no",
+        "Use regions BED file?": "yes" if assay == "cat" else "no",
+        "Path to regions BED file:": str(test_data_path / "plotting_coordinates.bed") if assay == "cat"
+        else "",
     }
 
     return prompts

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -382,9 +382,8 @@ def user_inputs(test_data_path, assay, assay_type, plot_bed, genome_files, mcc_f
         else "",
         "Resolution for MCC cooler files:": "100",
         "Make dataset for ML?": "yes" if assay == "cat" else "no",
-        "Use regions BED file?": "yes" if assay == "cat" else "no",
-        "Path to regions BED file:": str(test_data_path / "plotting_coordinates.bed") if assay == "cat"
-        else "",
+        "Use regions BED file?": "no",
+        "Binsize for dataset:": "10000" if assay == "cat" else "",
     }
 
     return prompts


### PR DESCRIPTION
This pull request introduces support for creating machine learning datasets in Seqnado workflows, along with enhancements to configuration handling and workflow logic. The changes include adding new dataset creation options, updating configuration templates, and implementing related rules in Snakemake workflows.

### Support for machine learning dataset creation:

* **Configuration updates:** Added `make_dataset`, `regions_bed`, and `binsize` fields to the `WorkflowConfig` and `Output` classes in `seqnado/config.py` and `seqnado/design.py`, enabling dataset creation options. [[1]](diffhunk://#diff-2d53a7a5c9fa2ba25d0279cb9bd1f156233bc2caf0cf48a5f281c08847810b57R98-R100) [[2]](diffhunk://#diff-9a86f028fdfd6e6e76662252b1cee891fb33b2fb78a682654f9f745766c5f690R1532-R1534)
* **Conditional features:** Extended `get_conditional_features` to include prompts for dataset creation, specifying either a BED file or binsize for regions.
* **Snakemake rules:** Implemented `make_dataset_regions` and `make_dataset_binsize` rules in `seqnado/workflow/rules/dataset.smk` for generating datasets from bigWig files using BED files or binsize.
* **Workflow integration:** Added `rules/dataset.smk` to Snakefiles for ATAC, ChIP, and CAT assays to enable dataset creation in these workflows. [[1]](diffhunk://#diff-7963ef0c734593078fe5d7059aef28ee4c3588379791547373a5bceab2e8da84R79) [[2]](diffhunk://#diff-3c7967089b385ddb07bc3d69cc96bb169cb2e61bf8daf8f9437bc373d9738e5aR84) [[3]](diffhunk://#diff-0b51714cf645e3bdff93d3ef4b4622ad01b8cb62b7424acb696aefc7b3c9e623L84-R84)

### Enhancements to configuration templates and logic:

* **Configuration template:** Updated `config.yaml.jinja` to include dataset-related fields (`make_dataset`, `regions_bed`, `binsize`) conditionally based on assay type.
* **Rendering logic:** Improved the `create_config` function to remove consecutive empty lines from rendered configuration files for cleaner output.

### Test updates:

* **Pipeline tests:** Modified `tests/test_pipelines.py` to include prompts for dataset creation in test cases, ensuring compatibility with new features. [[1]](diffhunk://#diff-5053985009d18dfbd4317f5bd7ee7e7dcd7957ec0f934a5f9e24dc073b20df36L340-R340) [[2]](diffhunk://#diff-5053985009d18dfbd4317f5bd7ee7e7dcd7957ec0f934a5f9e24dc073b20df36R384-R386)